### PR TITLE
Enhancement 11

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,6 +58,7 @@
         "algorithm": "cpp",
         "charconv": "cpp",
         "csignal": "cpp",
-        "cassert": "cpp"
+        "cassert": "cpp",
+        "iterator": "cpp"
     }
 }

--- a/fetch-json/src/fetch/fetch.cpp
+++ b/fetch-json/src/fetch/fetch.cpp
@@ -10,49 +10,133 @@
 namespace fetch {
     // Constructors
 
-    error::error(
-        const size_t status,
-        const std::string status_text,
-        const std::string text,
-        std::map<std::string, std::string> headers
-    ) {
+    error::error(const size_t status, const std::string status_text, const std::string text, fetch::header::map headers) {
         this->_status = status;
         this->_status_text = status_text;
         this->_text = text;
         this->_headers = headers;
     }
 
-    response::response(
-        const size_t status,
-        const std::string status_text,
-        std::map<std::string, std::string> headers,
-        const std::string text
-    ) {
+    response::response(const size_t status, const std::string status_text, fetch::header::map headers, const std::string text) {
         this->_status = status;
         this->_status_text = status_text;
         this->_headers = headers;
         this->_text = text;
+    }
+
+    header::value::value() {
+        this->_str = "";
+    }
+
+    header::value::value(const int value) {
+        this->_int = value;
+        this->_str = std::to_string(this->_int);
+        this->_parsed = true;
+    }
+
+    header::value::value(const std::string value) {
+        this->_str = value;
     }
 
     response::~response() {
         delete this->_json;
     }
 
+    // Operators
+
+    header::value::operator int() {
+        int value;
+
+        this->get(value);
+
+        return value;
+    }
+
+    header::value::operator std::string() {
+        return this->get();
+    }
+
+    int header::value::operator=(const int value) {
+        this->_set(value);
+
+        return this->_int;
+    }
+
+    std::string header::value::operator=(const std::string value) {
+        this->_set(value);
+
+        return this->_str;
+    }
+
+    bool header::value::operator==(const int value) {
+        int _value;
+
+        this->get(_value);
+
+        return _value == value;
+    }
+
+    bool header::value::operator==(const std::string value) {
+        return this->get() == value;
+    }
+
+    bool header::value::operator==(const struct value value) {
+        return this->get() == value.get();
+    }
+
+    bool header::value::operator!=(const int value) {
+        return !(*this == value);
+    }
+
+    bool header::value::operator!=(const std::string value) {
+        return !(*this == value);
+    }
+
+    bool header::value::operator!=(const struct value value) {
+        return !(*this == value);
+    }
+
     // Member Functions
 
-    std::string error::get(const std::string key) {
+    int header::value::_set(const int value) {
+        this->_int = value;
+        this->_str = std::to_string(this->_int);
+
+        return this->_int;
+    }
+
+    std::string header::value::_set(const std::string value) {
+        this->_str = value;
+        
+        return this->_str;
+    }
+
+    header::value error::get(const std::string key) {
         return this->_headers[key];
     }
 
-    std::string response::get(const std::string key) {
+    header::value response::get(const std::string key) {
         return this->_headers[key];
     }
 
-    std::map<std::string, std::string> error::headers() {
+    std::string header::value::get() const {
+        return this->_str;
+    }
+
+    void header::value::get(int& value) {
+        if (!this->_parsed) {
+            this->_int = parse_int(this->_str);
+            this->_parsed = true;
+        }
+
+        value = this->_int;
+    }
+
+    fetch::header::map error::headers() {
         return this->_headers;
     }
 
-    std::map<std::string, std::string> response::headers() {
+    fetch::header::map response::headers() {
         return this->_headers;
     }
 
@@ -101,7 +185,7 @@ namespace fetch {
 
     // Non-Member Functions
 
-    response request(std::map<std::string, std::string>& headers, const std::string url, const std::string method, const std::string body) {
+    response request(fetch::header::map& headers, const std::string url, const std::string method, const std::string body) {
         // Begin - Map start line
         // Map method
         std::stringstream ss(method + " ");
@@ -150,10 +234,10 @@ namespace fetch {
 
         // Map request headers
         if (body.length())
-            headers["content-length"] = std::to_string(body.length());
+            headers["content-length"] = (int)body.length();
 
         for (const auto& [key, value]: headers)
-            ss << key << ": " << value << "\r\n";
+            ss << key << ": " << value.get() << "\r\n";
 
         headers["host"] = host;
         // End - Map request headers
@@ -244,7 +328,7 @@ namespace fetch {
         // End - Parse status and status text
 
         // Parse response headers
-        std::map<std::string, std::string> _headers;
+        header::map _headers;
 
         while (getline(ss, str)) {
             std::vector<std::string> header;
@@ -266,12 +350,15 @@ namespace fetch {
         while (getline(ss, text))
             oss << trim_end(text) << "\r\n";
 
-        std::string content_length = _headers["content-length"];
-        size_t      _content_length = content_length.length() ?
-                        stoi(content_length) :
-                        _headers["transfer-encoding"] == "chunked" ?
-                        oss.str().length() :
-                        0;
+        int content_length;
+
+        _headers["content-length"].get(content_length);
+
+        size_t _content_length = content_length == INT_MIN ?
+                _headers["transfer-encoding"] == "chunked" ?
+                oss.str().length() :
+                0 :
+                content_length;
 
         text = oss.str().substr(0, _content_length);
 

--- a/fetch-json/src/fetch/fetch.h
+++ b/fetch-json/src/fetch/fetch.h
@@ -15,67 +15,113 @@
 namespace fetch {
     // Typedef
 
+    namespace header {
+        // Typdef
+
+        struct value {
+            // Constructors
+
+            value();
+
+            value(const int value);
+
+            value(const std::string value);
+
+            // Operators
+
+            operator    int();
+
+            operator    std::string();
+
+            int         operator=(const int value);
+
+            std::string operator=(const std::string value);
+
+            bool        operator==(const int value);
+
+            bool        operator==(const std::string value);
+
+            bool        operator==(const struct value value);
+
+            bool        operator!=(const int value);
+
+            bool        operator!=(const std::string value);
+
+            bool        operator!=(const struct value value);
+
+            // Member Functions
+
+            std::string get() const;
+
+            void        get(int& value);
+        private:
+            // Member Fields
+
+            int         _int;
+            bool        _parsed = false;
+            std::string _str;
+
+            // Member Functions
+
+            int         _set(const int value);
+            
+            std::string _set(const std::string value);
+        };
+
+        using map = std::map<std::string, header::value>;
+    };
+
     struct response_t {
         // Member Functions
 
         /**
          * Return response header
          */
-        virtual std::string                        get(const std::string key) = 0;
+        virtual header::value get(const std::string key) = 0;
 
-        virtual std::map<std::string, std::string> headers() = 0;
+        virtual header::map   headers() = 0;
 
-        virtual size_t                             status() const = 0;
+        virtual size_t        status() const = 0;
 
-        virtual std::string                        status_text() const = 0;
+        virtual std::string   status_text() const = 0;
 
-        virtual std::string                        text() const = 0;
+        virtual std::string   text() const = 0;
     };
 
     struct error: public std::exception, public response_t {
         // Constructors
 
-        error(
-            const size_t                       status,
-            const std::string                  status_text,
-            const std::string                  text = "",
-            std::map<std::string, std::string> headers = {}
-        );
+        error(const size_t status, const std::string status_text, const std::string text = "", header::map headers = {});
 
         // Member Functions
 
         /**
          * Return response header
          */
-        std::string                        get(const std::string key);
+        header::value get(const std::string key);
 
-        std::map<std::string, std::string> headers();
+        header::map   headers();
 
-        size_t                             status() const;
+        size_t        status() const;
 
-        std::string                        status_text() const;
+        std::string   status_text() const;
 
-        std::string                        text() const;
+        std::string   text() const;
 
-        const char*                        what() const throw();
+        const char*   what() const throw();
     private:
         // Member Fields
 
-        std::map<std::string, std::string> _headers;
-        size_t                             _status;
-        std::string                        _status_text;
-        std::string                        _text;
+        header::map _headers;
+        size_t      _status;
+        std::string _status_text;
+        std::string _text;
     };
 
     struct response: public response_t {
         // Constructors
 
-        response(
-            const size_t                       status,
-            const std::string                  status_text,
-            std::map<std::string, std::string> headers,
-            const std::string                  text
-        );
+        response(const size_t status, const std::string status_text, header::map headers, const std::string text);
 
         ~response();
 
@@ -84,40 +130,35 @@ namespace fetch {
         /**
          * Return response header
          */
-        std::string                        get(const std::string key);
+        header::value get(const std::string key);
 
-        std::map<std::string, std::string> headers();
+        header::map   headers();
 
-        json::object*                      json();
+        json::object* json();
 
-        size_t                             status() const;
+        size_t        status() const;
 
-        std::string                        status_text() const;
+        std::string   status_text() const;
 
-        std::string                        text() const;
+        std::string   text() const;
     private:
         // Member Fields
         
-        std::map<std::string, std::string> _headers;
-        json::object*                      _json = NULL;
-        size_t                             _status;
-        std::string                        _status_text;
-        std::string                        _text;
+        header::map   _headers;
+        json::object* _json = NULL;
+        size_t        _status;
+        std::string   _status_text;
+        std::string   _text;
     };
 
     // Non-Member Functions
     
-    response request(
-        std::map<std::string, std::string>& headers,
-        const std::string                   url,
-        const std::string                   method = "GET",
-        const std::string                   body = ""
-    );
+    response request(header::map& headers, const std::string url, const std::string method = "GET", const std::string body = "");
 
     /**
      * Returns request timeout
      */
-    size_t& timeout();
+    size_t&  timeout();
 }
 
 #endif /* fetch_h */

--- a/fetch-json/src/json/json.h
+++ b/fetch-json/src/json/json.h
@@ -150,9 +150,9 @@ namespace json {
         // Typedef
 
         struct iterator {
-            // Constructors
+            // Typdef
 
-            iterator(const size_t size, std::vector<object*> values);
+            friend json::array;
 
             // Operators
 
@@ -176,6 +176,10 @@ namespace json {
 
             bool      operator!=(const iterator& value) const;
         private:
+            // Constructors
+
+            iterator(const size_t size, std::vector<object*> values);
+
             // Member Fields
 
             int                  _index = 0;

--- a/fetch-json/src/main.cpp
+++ b/fetch-json/src/main.cpp
@@ -10,16 +10,13 @@
 
 using namespace fetch;
 using namespace json;
-using namespace mysocket;
 using namespace std;
 
-map<string, string> headers = {{ "content-type", "application/json" }};
+header::map headers = {{ "content-type", header::value("application/json") }};
 
 int main(int argc, const char * argv[]) {
-    // auto server = new tcp_server(8082);
-
     string url = "http://localhost:8081/greeting";
-    // string url = "http://localhost:8082/greeting";
+    // string url = "http://localhost:8081/no-reply";
 
     string method = "POST";
     auto   body = new object((vector<object*>) {
@@ -36,8 +33,6 @@ int main(int argc, const char * argv[]) {
             cout << response.text() << endl;
         }
     } catch (fetch::error& e) {
-        // server->close();
-
         if (e.text().length())
             throw fetch::error(e.status(), e.text(), e.text(), e.headers());
         

--- a/fetch-json/src/util/util.cpp
+++ b/fetch-json/src/util/util.cpp
@@ -153,7 +153,7 @@ bool is_int(const std::string value) {
     
     // leading positive (+) or negative (-) sign
     if (i != value.length() && (value[i] == '+' || value[i] == '-'))
-        ++i;
+        i++;
     
     if (i == value.length())
         return false;
@@ -176,13 +176,13 @@ bool is_number(const std::string value) {
     
     // leading positive (+) or negative (-) sign
     if (value[i] == '+' || value[i] == '-')
-        ++i;
+        i++;
     
     // find decimal point
     int j = i;
     
     while (j < value.length() && value[j] != '.')
-        ++j;
+        j++;
     
     // if no decimal point is found, start at the beginning (after the sign, if applicable)
     // find exponent

--- a/test-server/src/api-doc.yaml
+++ b/test-server/src/api-doc.yaml
@@ -34,6 +34,34 @@ paths:
             application/json:
               schema:
                 type: string
+
+  "/no-reply":
+    get:
+      operationId: doNotReply
+      responses:
+        "200":
+          description: Successful request
+    post:
+      operationId: doNotReply
+      responses:
+        "200":
+          description: Successful request
+    put:
+      operationId: doNotReply
+      responses:
+        "200":
+          description: Successful request
+    patch:
+      operationId: doNotReply
+      responses:
+        "200":
+          description: Successful request
+    delete:
+      operationId: doNotReply
+      responses:
+        "200":
+          description: Successful request
+
   "/ping":
     get:
       operationId: ping

--- a/test-server/src/index.js
+++ b/test-server/src/index.js
@@ -52,6 +52,7 @@ const main = () => {
 
             res.setHeader("content-type", "text/plain").send(greeting.create(req.body));   
         },
+        doNotReply: (c, req, res) => {},
         ping: (c, req, res) => res.send({ message: "Hello, world!"}),
         notFound: (c, req, res) => res.status(404).json(`Cannot ${req.method} ${req.url}`)
     })


### PR DESCRIPTION
Enhancement #11

- Create fetch::header::value type to serve both int and string values

Expected behavior:

fetch::header::value host = "127.0.0.1:8000”;
fetch::header::value content_length = 0;

std::string _host = host;
int _content_length = content_length;
